### PR TITLE
Upgrade Guzzle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ php:
 - 5.6
 - 7.0
 - 7.1
-- 7.2.7
-- 7.2.8
-- 7.2.9
 - 7.2
 install: make install
 script: make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ php:
 - 7.0
 - 7.1
 - 7.2.7
+- 7.2.8
+- 7.2.9
+- 7.2
 install: make install
 script: make test
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: php
 php:
-- 5.3
-- 5.4
 - 5.5
 - 5.6
 install: make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: php
 php:
 - 5.5
 - 5.6
+- 7.0
+- 7.1
+- 7.2
 install: make install
 script: make test
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ php:
 - 5.6
 - 7.0
 - 7.1
-- 7.2
+- 7.2.7
 install: make install
 script: make test
 sudo: false

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A PHP API client for the [Public Media Platform](http://publicmediaplatform.org)
 
 ## Requirements
 
-PHP version >= 5.3.3.  And a [PMP client-id/secret](https://support.pmp.io/login) for your PMP user.
+PHP version >= 5.5.  And a [PMP client-id/secret](https://support.pmp.io/login) for your PMP user.
 
 ## Installation
 
@@ -420,6 +420,6 @@ Report any bugs or feature-requests via the issue tracker.
 
 ## License
 
-The PMP `phpsdk` is free software, and may be redistributed under the MIT-LICENSE.
+The PMP PHP SDK is free software, and may be redistributed under the MIT-LICENSE.
 
 Thanks for listening!

--- a/README.md
+++ b/README.md
@@ -390,7 +390,10 @@ if ($cache_str) {
 }
 ```
 
-Note that if the serialized string is somehow corrupt, the call to `unserialize()` will return `false` and also might generate a PHP `RuntimeException`.
+Note that if the serialized string is somehow corrupt:
+* for PHP 7.2.8 and later, the call to `unserialize()` will return `false` and also might generate a PHP `RuntimeException` 
+* for PHP 7.2.7 and earlier, the call to `unserialize()` will generate a PHP `RuntimeException`
+
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ if ($cache_str) {
 }
 ```
 
-Not that if the serialized string is somehow corrupt, the call to `unserialize()` will generate a PHP `RuntimeException`.
+Note that if the serialized string is somehow corrupt, the call to `unserialize()` will return `false` and also might generate a PHP `RuntimeException`.
 
 ## Developing
 

--- a/README.md
+++ b/README.md
@@ -382,10 +382,17 @@ $my_cache_mechanism->set('pmpsdk', $cache_str, 3600);
 // awhile later, in a different HTTP request
 $cache_str = $my_cache_mechanism->get('pmpsdk');
 if ($cache_str) {
-    $sdk = unserialize($cache_str);
-
-    // now this only generates 1 request, since we already have both the
-    // PMP home doc and an auth token
+    try {
+        $sdk = unserialize($cache_str);
+        if ($sdk === false) {
+            throw new \RuntimeException('Failed to unserialize SDK');
+        }
+    } catch (\RuntimeException $e) {
+        // failed to unserialize SDK, so need to start fresh
+        $sdk = new \Pmp\Sdk($host, 'client-id', 'client-secret'); 
+    }
+    // if retrieved from cache successfully, this would only generate 1 request, 
+    // since we would already have both the PMP home doc and an auth token
     $doc = $sdk->fetchDoc('SOME-GUID');
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,8 @@
   "homepage": "https://github.com/npr/pmp-php-sdk",
   "license": "MIT",
   "require": {
-    "php": ">=5.3.3",
-    "guzzle/guzzle": "3.9.2"
+    "php": ">=5.5",
+    "guzzlehttp/guzzle": "^6.3"
   },
   "autoload":{
     "psr-0": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,74 +1,164 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "hash": "28e102f8f20d75f69ff286a06f7b8f39",
+    "content-hash": "90163814787a8a95d80ee8c0373475bb",
     "packages": [
         {
-            "name": "guzzle/guzzle",
-            "version": "v3.9.2",
+            "name": "guzzlehttp/guzzle",
+            "version": "6.3.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/guzzle/guzzle3.git",
-                "reference": "54991459675c1a2924122afbb0e5609ade581155"
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle3/zipball/54991459675c1a2924122afbb0e5609ade581155",
-                "reference": "54991459675c1a2924122afbb0e5609ade581155",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/407b0cb880ace85c9b63c5f9551db498cb2d50ba",
+                "reference": "407b0cb880ace85c9b63c5f9551db498cb2d50ba",
                 "shasum": ""
             },
             "require": {
-                "ext-curl": "*",
-                "php": ">=5.3.3",
-                "symfony/event-dispatcher": "~2.1"
-            },
-            "replace": {
-                "guzzle/batch": "self.version",
-                "guzzle/cache": "self.version",
-                "guzzle/common": "self.version",
-                "guzzle/http": "self.version",
-                "guzzle/inflection": "self.version",
-                "guzzle/iterator": "self.version",
-                "guzzle/log": "self.version",
-                "guzzle/parser": "self.version",
-                "guzzle/plugin": "self.version",
-                "guzzle/plugin-async": "self.version",
-                "guzzle/plugin-backoff": "self.version",
-                "guzzle/plugin-cache": "self.version",
-                "guzzle/plugin-cookie": "self.version",
-                "guzzle/plugin-curlauth": "self.version",
-                "guzzle/plugin-error-response": "self.version",
-                "guzzle/plugin-history": "self.version",
-                "guzzle/plugin-log": "self.version",
-                "guzzle/plugin-md5": "self.version",
-                "guzzle/plugin-mock": "self.version",
-                "guzzle/plugin-oauth": "self.version",
-                "guzzle/service": "self.version",
-                "guzzle/stream": "self.version"
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.4",
+                "php": ">=5.5"
             },
             "require-dev": {
-                "doctrine/cache": "~1.3",
-                "monolog/monolog": "~1.0",
-                "phpunit/phpunit": "3.7.*",
-                "psr/log": "~1.0",
-                "symfony/class-loader": "~2.1",
-                "zendframework/zend-cache": "2.*,<2.3",
-                "zendframework/zend-log": "2.*,<2.3"
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0",
+                "psr/log": "^1.0"
+            },
+            "suggest": {
+                "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.9-dev"
+                    "dev-master": "6.3-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Guzzle": "src/",
-                    "Guzzle\\Tests": "tests/"
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
                 }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2018-04-22T15:46:56+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "reference": "a59da6cf61d80060647ff4d3eb2c03a2bc694646",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "time": "2016-12-20T10:07:11+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "reference": "f5b8a8512e2b58b0071a7280e39f14f72e05d87c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0",
+                "psr/http-message": "~1.0"
+            },
+            "provide": {
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -81,61 +171,48 @@
                     "homepage": "https://github.com/mtdowling"
                 },
                 {
-                    "name": "Guzzle Community",
-                    "homepage": "https://github.com/guzzle/guzzle/contributors"
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
                 }
             ],
-            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
-            "homepage": "http://guzzlephp.org/",
+            "description": "PSR-7 message implementation that also provides common utility methods",
             "keywords": [
-                "client",
-                "curl",
-                "framework",
                 "http",
-                "http client",
-                "rest",
-                "web service"
+                "message",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
             ],
-            "time": "2014-08-11 04:32:36"
+            "time": "2017-03-20T17:10:46+00:00"
         },
         {
-            "name": "symfony/event-dispatcher",
-            "version": "v2.6.3",
-            "target-dir": "Symfony/Component/EventDispatcher",
+            "name": "psr/http-message",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/EventDispatcher.git",
-                "reference": "40ff70cadea3785d83cac1c8309514b36113064e"
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/EventDispatcher/zipball/40ff70cadea3785d83cac1c8309514b36113064e",
-                "reference": "40ff70cadea3785d83cac1c8309514b36113064e",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
-            },
-            "require-dev": {
-                "psr/log": "~1.0",
-                "symfony/config": "~2.0,>=2.0.5",
-                "symfony/dependency-injection": "~2.6",
-                "symfony/expression-language": "~2.6",
-                "symfony/stopwatch": "~2.3"
-            },
-            "suggest": {
-                "symfony/dependency-injection": "",
-                "symfony/http-kernel": ""
+                "php": ">=5.3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.6-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Symfony\\Component\\EventDispatcher\\": ""
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -144,17 +221,21 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
                 }
             ],
-            "description": "Symfony EventDispatcher Component",
-            "homepage": "http://symfony.com",
-            "time": "2015-01-05 14:28:40"
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2016-08-06T14:39:51+00:00"
         }
     ],
     "packages-dev": [],
@@ -164,7 +245,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.3"
+        "php": ">=5.5"
     },
     "platform-dev": []
 }

--- a/src/Pmp/Sdk/CollectionDocJsonLink.php
+++ b/src/Pmp/Sdk/CollectionDocJsonLink.php
@@ -1,7 +1,7 @@
 <?php
 namespace Pmp\Sdk;
 
-use \Guzzle\Parser\UriTemplate\UriTemplate;
+use \GuzzleHttp\UriTemplate;
 
 /**
  * PMP CollectionDoc link

--- a/src/Pmp/Sdk/Http.php
+++ b/src/Pmp/Sdk/Http.php
@@ -125,11 +125,8 @@ class Http
             $resp = $e->getResponse();
         }
         catch (ConnectException $e) {
-            $err_data['code'] = $e->getCode();
-            $err_data['message'] = $e->getMessage();
-            $err_data['handler'] = $e->getHandlerContext();
-
-            throw new Exception\RemoteException('Unable to complete request', $err_data);
+            print_r($e->getHandlerContext());
+            throw new Exception\RemoteException("Unable to complete request CODE {$e->getCode()} MESSAGE {$e->getMessage()}", $err_data);
         }
         $code = $resp->getStatusCode();
         $body = $resp->getBody();

--- a/src/Pmp/Sdk/Http.php
+++ b/src/Pmp/Sdk/Http.php
@@ -123,11 +123,11 @@ class Http
         catch (BadResponseException $e) {
             $resp = $e->getResponse();
         }
-        catch (GuzzleException $e) {
-            $err_data['code'] = $e->getCode();
-            $err_data['message'] = $e->getMessage();
-            throw new Exception\RemoteException('Unable to complete request', $err_data);
-        }
+//        catch (GuzzleException $e) {
+//            $err_data['code'] = $e->getCode();
+//            $err_data['message'] = $e->getMessage();
+//            throw new Exception\RemoteException('Unable to complete request', $err_data);
+//        }
         $code = $resp->getStatusCode();
         $body = $resp->getBody();
         $json = json_decode($body);

--- a/src/Pmp/Sdk/Http.php
+++ b/src/Pmp/Sdk/Http.php
@@ -114,7 +114,6 @@ class Http
     static private function _sendRequest($method, $url, $opts) {
         $client = new Client();
         $opts['timeout'] = self::TIMEOUT_S;
-        $opts['http_errors'] = false;
         $err_data = array('method' => $method, 'url' => $url);
 
         // make the request, catching guzzle errors

--- a/src/Pmp/Sdk/Http.php
+++ b/src/Pmp/Sdk/Http.php
@@ -124,6 +124,8 @@ class Http
             $resp = $e->getResponse();
         }
         catch (GuzzleException $e) {
+            $err_data['code'] = $e->getCode();
+            $err_data['message'] = $e->getMessage();
             throw new Exception\RemoteException('Unable to complete request', $err_data);
         }
         $code = $resp->getStatusCode();

--- a/src/Pmp/Sdk/Http.php
+++ b/src/Pmp/Sdk/Http.php
@@ -3,7 +3,6 @@ namespace Pmp\Sdk;
 
 use \GuzzleHttp\Client;
 use \GuzzleHttp\Exception\GuzzleException;
-use \GuzzleHttp\Exception\ConnectException;
 use \GuzzleHttp\Exception\BadResponseException;
 
 /**

--- a/src/Pmp/Sdk/Http.php
+++ b/src/Pmp/Sdk/Http.php
@@ -3,6 +3,7 @@ namespace Pmp\Sdk;
 
 use \GuzzleHttp\Client;
 use \GuzzleHttp\Exception\GuzzleException;
+use \GuzzleHttp\Exception\ConnectException;
 use \GuzzleHttp\Exception\BadResponseException;
 
 /**
@@ -123,11 +124,13 @@ class Http
         catch (BadResponseException $e) {
             $resp = $e->getResponse();
         }
-//        catch (GuzzleException $e) {
-//            $err_data['code'] = $e->getCode();
-//            $err_data['message'] = $e->getMessage();
-//            throw new Exception\RemoteException('Unable to complete request', $err_data);
-//        }
+        catch (ConnectException $e) {
+            $err_data['code'] = $e->getCode();
+            $err_data['message'] = $e->getMessage();
+            $err_data['handler'] = $e->getHandlerContext();
+
+            throw new Exception\RemoteException('Unable to complete request', $err_data);
+        }
         $code = $resp->getStatusCode();
         $body = $resp->getBody();
         $json = json_decode($body);

--- a/src/Pmp/Sdk/Http.php
+++ b/src/Pmp/Sdk/Http.php
@@ -3,7 +3,7 @@ namespace Pmp\Sdk;
 
 use \GuzzleHttp\Client;
 use \GuzzleHttp\Exception\GuzzleException;
-use \GuzzleHttp\Exception\RequestException;
+use \GuzzleHttp\Exception\BadResponseException;
 
 /**
  * PMP common HTTP utils
@@ -120,7 +120,7 @@ class Http
         try {
             $resp = $client->request($method, $url, $opts);
         }
-        catch (RequestException $e) {
+        catch (BadResponseException $e) {
             $resp = $e->getResponse();
         }
         catch (GuzzleException $e) {

--- a/src/Pmp/Sdk/Http.php
+++ b/src/Pmp/Sdk/Http.php
@@ -124,9 +124,11 @@ class Http
         catch (BadResponseException $e) {
             $resp = $e->getResponse();
         }
-        catch (ConnectException $e) {
-            print_r($e->getHandlerContext());
-            throw new Exception\RemoteException("Unable to complete request CODE {$e->getCode()} MESSAGE {$e->getMessage()}", $err_data);
+        catch (GuzzleException $e) {
+            if (strpos($e->getMessage(), 'cURL error 6: Could not resolve host') !== false) {
+                throw new Exception\HostException('Unable to resolve host', $err_data);
+            }
+            throw $e;
         }
         $code = $resp->getStatusCode();
         $body = $resp->getBody();

--- a/t/020-serialize.t
+++ b/t/020-serialize.t
@@ -16,14 +16,13 @@ ok( $new_sdk = unserialize($serial),     'normal - unserialize Sdk' );
 ok( $doc = $new_sdk->fetchTopic('arts'), 'normal - fetch doc' );
 
 // invalid string (turn off notices)
-$str2 = substr($serial, 0, 500) . 'foobar' . substr($serial, 500);
 $level = error_reporting(E_ALL & ~E_NOTICE);
-try {
-    $bad_sdk = unserialize($str2);
-    fail( 'invalid - no exception' );
-}
-catch (\RuntimeException $e) {
-    pass( 'invalid - throws runtime exception' );
+$bad_serial = substr($serial, 0, 500) . 'foobar' . substr($serial, 500);
+$bad_sdk = unserialize($bad_serial);
+if ($bad_sdk !== false) {
+    fail('invalid - unserialized without failure');
+} else {
+    pass('invalid - failed to unserialize');
 }
 error_reporting($level);
 
@@ -35,8 +34,6 @@ ok( $doc = $exp_sdk->fetchTopic('arts'),                  'expired - fetch doc' 
 
 // zipped serialization
 ok( $sdk = new \Pmp\Sdk($host, $id, $secret, array('serialzip' => true)), 'instantiate new serialzip Sdk' );
-
-// serialize and compare it
 ok( $serialzip = serialize($sdk),                 'zipped - serialize Sdk' );
 cmp_ok( strlen($serialzip), '<', strlen($serial), 'zipped - is pretty small' );
 ok( $zip_sdk = unserialize($serialzip),           'zipped - unserialize Sdk' );

--- a/t/020-serialize.t
+++ b/t/020-serialize.t
@@ -17,7 +17,7 @@ ok( $doc = $new_sdk->fetchTopic('arts'), 'normal - fetch doc' );
 
 // invalid string (turn off notices)
 $str2 = substr($serial, 0, 500) . 'foobar' . substr($serial, 500);
-//$level = error_reporting(E_ALL & ~E_NOTICE);
+$level = error_reporting(E_ALL & ~E_NOTICE);
 try {
     $bad_sdk = unserialize($str2);
     fail( 'invalid - no exception' );
@@ -25,7 +25,7 @@ try {
 catch (\RuntimeException $e) {
     pass( 'invalid - throws runtime exception' );
 }
-//error_reporting($level);
+error_reporting($level);
 
 // expired token
 ok( $auth = new \Pmp\Sdk\AuthClient($host, $id, $secret), 'expired - get new AuthUser' );

--- a/t/020-serialize.t
+++ b/t/020-serialize.t
@@ -18,11 +18,18 @@ ok( $doc = $new_sdk->fetchTopic('arts'), 'normal - fetch doc' );
 // invalid string (turn off notices)
 $level = error_reporting(E_ALL & ~E_NOTICE);
 $bad_serial = substr($serial, 0, 500) . 'foobar' . substr($serial, 500);
-$bad_sdk = unserialize($bad_serial);
-if ($bad_sdk !== false) {
-    fail('invalid - unserialized without failure');
-} else {
-    pass('invalid - failed to unserialize');
+try {
+    $bad_sdk = unserialize($bad_serial);
+
+    // for PHP 7.2.8 and later
+    if ($bad_sdk !== false) {
+        fail('invalid - unserialized without failure');
+    } else {
+        pass('invalid - failed to unserialize');
+    }
+} catch (\RuntimeException $e) {
+    // for PHP 7.2.7 and earlier
+    pass('invalid - throws runtime exception');
 }
 error_reporting($level);
 

--- a/t/020-serialize.t
+++ b/t/020-serialize.t
@@ -17,7 +17,7 @@ ok( $doc = $new_sdk->fetchTopic('arts'), 'normal - fetch doc' );
 
 // invalid string (turn off notices)
 $str2 = substr($serial, 0, 500) . 'foobar' . substr($serial, 500);
-$level = error_reporting(E_ALL & ~E_NOTICE);
+//$level = error_reporting(E_ALL & ~E_NOTICE);
 try {
     $bad_sdk = unserialize($str2);
     fail( 'invalid - no exception' );
@@ -25,7 +25,7 @@ try {
 catch (\RuntimeException $e) {
     pass( 'invalid - throws runtime exception' );
 }
-error_reporting($level);
+//error_reporting($level);
 
 // expired token
 ok( $auth = new \Pmp\Sdk\AuthClient($host, $id, $secret), 'expired - get new AuthUser' );


### PR DESCRIPTION
Upgrade to Guzzle 6.3. Which means a minimum of PHP 5.5 is required now.

Also, it seems that beginning in PHP 7.2.8, unserializing a corrupt serialization will not produce an exception even if it is thrown in the custom unserialization method (as it is in the main `Sdk` class).  This means that clients will have to check that the unserialized SDK is not equal to `false` in addition to catching any unserialization exceptions that might come for other reasons (such as there being no unzip functions available for a zipped serialization).  This could be a breaking change for clients that rely only on catching exceptions while unserializing. 

So, this pull request represents a few backward-incompatible changes (minimum PHP 5.5 and new unserialization behavior).

Out of scope -  bringing anything up to PHP 5.5+ standards and syntax.