### PR TITLE
Handle missing credentials

### DIFF
--- a/src/Pmp/Sdk/AuthClient.php
+++ b/src/Pmp/Sdk/AuthClient.php
@@ -56,6 +56,9 @@ class AuthClient
     public function __construct($host, $id, $secret, CollectionDocJson $home = null)
     {
         $this->_host = $host;
+        if (empty($id) || empty($secret)) {
+            throw new AuthException("Missing client credentials");
+        }
         $this->_clientAuth = 'Basic ' . base64_encode($id . ':' . $secret);
         $this->home = $home;
         $this->getToken();

--- a/t/002-auth-client.t
+++ b/t/002-auth-client.t
@@ -68,3 +68,14 @@ try {
 catch (AuthException $e) {
     pass( 'invalid client - throws exception' );
 }
+
+// missing client credentials
+try {
+    $bad_client = new AuthClient($host, $client_id, '');
+    $bad_client->getToken();
+    fail( 'invalid client - no exception' );
+}
+catch (AuthException $e) {
+    pass( 'invalid client - throws exception' );
+}
+

--- a/t/002-auth-client.t
+++ b/t/002-auth-client.t
@@ -11,7 +11,7 @@ use \Pmp\Sdk\Exception\HostException as HostException;
 //
 
 // plan and connect
-list($host, $client_id, $client_secret) = pmp_client_plan(24);
+list($host, $client_id, $client_secret) = pmp_client_plan(25);
 ok( $auth = new AuthClient($host, $client_id, $client_secret), 'instantiate new AuthClient' );
 
 // get a token


### PR DESCRIPTION
The AuthClient constructor will now throw an AuthException if either client ID or client secret are empty.  Since this is being thrown where AuthException was thrown before for failed attempt to get a token, this should not cause any problems for clients, so long as they are not specifically looking for the exception messages previously defined (this new use of AuthException has its own message).